### PR TITLE
Bump the django-crispy-forms from 1.13.0 to 1.14.0 for Support of Python 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # django-blog-project
 
 ## Dependencies:
-`Django==4.0.1`
-`Pillow==9.0.0`
-`django-crispy-forms==1.13.0`
-`django-cleanup==5.2.0`
+- `Django==4.0.1`
+- `Pillow==9.0.0`
+- `django-crispy-forms==1.14.0`
+- `django-cleanup==5.2.0`
 
 ## Installation Process
 The Given Project needs virtual environment to work, so please follow below steps.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Django==4.0.1
 Pillow==9.0.0
-django-crispy-forms==1.13.0
+django-crispy-forms==1.14.0
 django-cleanup==5.2.0


### PR DESCRIPTION
But It Drops Support for django 3.1 and python 3.6
But The Series of Django 4.0 and after Only Support the python 3.8 and above already